### PR TITLE
Fix Enter VR on HTC Vive

### DIFF
--- a/scripts/moar.js
+++ b/scripts/moar.js
@@ -222,7 +222,7 @@ Moar.setupVRButton = function(){
 			})
 			three.classList.remove( 'show' )
 			button.classList.add( 'engaged' )
-			window.setTimeout( function(){ Moar.effect.requestPresent() }, 500 )
+			Moar.effect.requestPresent();
 		}
 	}
 	window.addEventListener( 'vrdisplaypresentchange', function( event ){


### PR DESCRIPTION
https://github.com/dmarcos helped me debug this on the webvr slack. He said:

> The 500ms delay makes the callback not be considered a user action anymore and cannot initiate vr mode

So I removed the setTimeout. It works now on my Vive. Fixes #1 